### PR TITLE
Enhance GitHub stats widgets and links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,12 @@ Atualmente atuo com administração de servidores, redes, segurança, cloud e su
 ## 📈 GitHub Stats
 
 <div align="center">
-
-![Lucas Gonella GitHub Stats](https://github-readme-stats.vercel.app/api?username=lucasgonella&show_icons=true&theme=dracula&include_all_commits=true&count_private=true)
-
-![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=lucasgonella&layout=compact&theme=dracula)
-
+  <a href="https://github.com/lucasgonella">
+    <img height="170" alt="Estatísticas do GitHub de Lucas Gonella" src="https://github-readme-stats.vercel.app/api?username=lucasgonella&amp;show_icons=true&amp;theme=dracula&amp;include_all_commits=true&amp;count_private=true&amp;hide_border=true&amp;cache_seconds=21600" />
+  </a>
+  <a href="https://github.com/lucasgonella?tab=repositories">
+    <img height="170" alt="Linguagens mais usadas por Lucas Gonella" src="https://github-readme-stats.vercel.app/api/top-langs/?username=lucasgonella&amp;layout=compact&amp;theme=dracula&amp;hide_border=true&amp;langs_count=8&amp;cache_seconds=21600" />
+  </a>
 </div>
 
 ---


### PR DESCRIPTION
### Motivation

- Improve the visual presentation and accessibility of the GitHub stats section in `README.md` by using linked images with descriptive `alt` text and fixed heights.
- Reduce visual clutter and improve cache behavior by hiding image borders and adding caching parameters to the badges.
- Provide a direct link to the repository list to help visitors navigate to projects more easily.

### Description

- Replaced the previous raw badge image blocks in `README.md` with two anchored `<img>` elements linking to the user profile and repositories. 
- Added `height` and `alt` attributes to the images and set `hide_border=true` and `cache_seconds=21600` query parameters for improved rendering and caching.
- Adjusted the top-langs widget to include `langs_count=8` and clarified image alt text to reflect the content.
- Removed redundant blank lines and slightly reorganized the GitHub stats HTML block for cleaner layout.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b33b1f97c8323b1102887c32e49cd)